### PR TITLE
lock version of geoalchemy2

### DIFF
--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -1,6 +1,6 @@
 -e git+https://github.com/ckan/ckan#egg=ckan
 -r https://raw.githubusercontent.com/ckan/ckan/master/requirements.txt
-GeoAlchemy>=0.6
+GeoAlchemy2==0.5.0
 OWSLib==0.8.6
 lxml>=2.3
 pyparsing==1.5.6

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -1,5 +1,5 @@
 GeoAlchemy>=0.6
-GeoAlchemy2>=0.2.4
+GeoAlchemy2==0.5.0
 Shapely>=1.2.13
 OWSLib==0.8.6
 lxml>=2.3


### PR DESCRIPTION
A new version of `geoalchemy2` was causing the application to crash.

We've locked it to a known working version.